### PR TITLE
Re-resubmit: Added code to look for resources and load classes in WEB-INF\libs, included annotated models in swagger doc and added filtering by class prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .settings
 .classpath
 .factorypath
+*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ target/
 .settings
 .classpath
 .factorypath
-*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 .classpath
 .factorypath
 
+*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .settings
 .classpath
 .factorypath
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Swaggerdocgen Maven Plug-in provides a tool for generating Swagger documents for you web applications. The Swaggerdocgen Maven plug-in is available on the [Maven central](http://search.maven.org/#search%7Cga%7C1%7Cswaggerdocgen) repository. Alternatively, you can refer to [Installation](#installation) section and follow the steps to install the plug-in in your local repository.
 
-*Note:* When using the swaggerdocgen goals, it is assumed that the package phase is already done. The Plugin is not responsible for packaging web applications into WARs.
+*Note:* When using the swaggerdocgen goals, it is assumed that the package phase is already done. The Plugin is not responsible for packaging web applications into WARs.2222
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Swaggerdocgen Maven Plug-in provides a tool for generating Swagger documents for you web applications. The Swaggerdocgen Maven plug-in is available on the [Maven central](http://search.maven.org/#search%7Cga%7C1%7Cswaggerdocgen) repository. Alternatively, you can refer to [Installation](#installation) section and follow the steps to install the plug-in in your local repository.
 
-*Note:* When using the swaggerdocgen goals, it is assumed that the package phase is already done. The Plugin is not responsible for packaging web applications into WARs.2222
+*Note:* When using the swaggerdocgen goals, it is assumed that the package phase is already done. The Plugin is not responsible for packaging web applications into WARs.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Example:
                 </executions>
                 <configuration>
                     <outputFile>${project.build.directory}/swagger.json</outputFile>
+                    <prefixes>
+                        <prefix>my.class.prefix</prefix>
+                        <prefix>my.other.class.prefix</prefix>
+                    </prefixes>
                 </configuration>
             </plugin>
         </plugins>

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Parameters used by this goal:
 | --------  | ----------- | -------  |
 | outputFile | Location of the generated Swagger document. **Default value:** \${project.build.directory}/swagger.yaml | No |
 | warFile| Location of the WAR to be scanned. **Default value:** \${project.build.directory}/\${project.build.finalName}.war | No |
+| packageName| Only scan class names beginning with this string **Default value:** "" | No |
+| tmpPath| Location where the war's WEB-INF\lib will be unpacked temporarily **Default value:** \${project.build.directory} | No |
+
 
 Example:
 ```xml
@@ -134,13 +137,18 @@ You can also specify the full path where you want your swagger file to be produc
 $ java -cp ".:target/swaggerdocgen-maven-plugin-<plugin_version>-jar-with-dependencies.jar:/libertyRuntime/dev/api/spec/*" net.wasdev.maven.plugins.swaggerdocgen.GenerateSwaggerFile /../path-to-application/app.war /path-to-swagger/swagger.json
 ```
 
+You can specify the prefix of the classes to scan and the path where the war's WEB-INF/lib will be unpacked temporarily on the command line too:
+```sh
+$ java -cp ".:target/swaggerdocgen-maven-plugin-<plugin_version>-jar-with-dependencies.jar:/libertyRuntime/dev/api/spec/*" net.wasdev.maven.plugins.swaggerdocgen.GenerateSwaggerFile /../path-to-application/app.war /path-to-swagger/swagger.json my.package.name /path/to/unpack/
+```
+
 ## FAQ
 
 ##### Q: I ran the plugin but the generated file is empty.
-A: The plugin looks in the WEB-INF\classes folder in the WAR file to find the classes to scan. If there are no eligible classes there then the generated file is empty.
+A: The plugin looks in the WEB-INF\classes folder and in the jars in WEB-INF\lib inside the WAR to find the classes to scan. If there are no eligible classes there then the generated file is empty.
 
 ##### Q: I get a java.lang.NoClassDefFoundError!
-A: Swagger and the plugin attempt to load the classes they scan for annotations. This may mean that all classes reffered by them are also loaded. For example, the types of the members of a scanned class are also loaded. The plugin looks up classes in the WEB-INF\classes folder and in the jars under WEB-INF\libs, plus the default class path. If a class needs to be loaded that isn't in any of these paths you get that error. This can be tha case for JavaEE classes provided by the container (Servlet, JAX-RS, etc.), for example java.lang.NoClassDefFoundError: Ljavax/servlet/http/HttpServletRequest
+A: Swagger and the plugin attempt to load the classes they scan for annotations. This may mean that all classes referred by them are also loaded. For example, the types of the members of a scanned class are also loaded. The plugin looks up classes in the WEB-INF\classes folder and in the jars under WEB-INF\libs, apart from the other usual class paths. If a class needs to be loaded that isn't in any of these paths you get that error. This can be the case for JavaEE classes provided by the container (Servlet, JAX-RS, etc.), for example java.lang.NoClassDefFoundError: Ljavax/servlet/http/HttpServletRequest
  
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Parameters used by this goal:
 | --------  | ----------- | -------  |
 | outputFile | Location of the generated Swagger document. **Default value:** \${project.build.directory}/swagger.yaml | No |
 | warFile| Location of the WAR to be scanned. **Default value:** \${project.build.directory}/\${project.build.finalName}.war | No |
-| packageName| Only scan class names beginning with this string **Default value:** "" | No |
+| prefixes| Only scan class names beginning with one of these strings **Default value:** "" | No |
 | tmpPath| Location where the war's WEB-INF\lib will be unpacked temporarily **Default value:** \${project.build.directory} | No |
 
 
@@ -137,9 +137,9 @@ You can also specify the full path where you want your swagger file to be produc
 $ java -cp ".:target/swaggerdocgen-maven-plugin-<plugin_version>-jar-with-dependencies.jar:/libertyRuntime/dev/api/spec/*" net.wasdev.maven.plugins.swaggerdocgen.GenerateSwaggerFile /../path-to-application/app.war /path-to-swagger/swagger.json
 ```
 
-You can specify the prefix of the classes to scan and the path where the war's WEB-INF/lib will be unpacked temporarily on the command line too:
+You can specify the prefixes of the classes to scan and the path where the war's WEB-INF/lib will be unpacked temporarily on the command line too:
 ```sh
-$ java -cp ".:target/swaggerdocgen-maven-plugin-<plugin_version>-jar-with-dependencies.jar:/libertyRuntime/dev/api/spec/*" net.wasdev.maven.plugins.swaggerdocgen.GenerateSwaggerFile /../path-to-application/app.war /path-to-swagger/swagger.json my.package.name /path/to/unpack/
+$ java -cp ".:target/swaggerdocgen-maven-plugin-<plugin_version>-jar-with-dependencies.jar:/libertyRuntime/dev/api/spec/*" net.wasdev.maven.plugins.swaggerdocgen.GenerateSwaggerFile /../path-to-application/app.war /path-to-swagger/swagger.json /path/to/unpack/ my.class.prefix1 my.class.prefix2
 ```
 
 ## FAQ

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
-            <version>1.5.16</version>
+            <version>1.5.12</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
-            <version>1.5.12</version>
+            <version>1.5.16</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/CreateMojo.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/CreateMojo.java
@@ -53,6 +53,12 @@ public class CreateMojo extends AbstractMojo {
 	 */
 	@Parameter(defaultValue = "${project.build.directory}/${project.build.finalName}.war", required = false)
 	private File warFile;
+	
+	/**
+	 * Location of the target WAR file.
+	 */
+	@Parameter(defaultValue = "", required = false)
+	private String packageName;
 
 	/*
 	 * (non-Javadoc)
@@ -62,7 +68,14 @@ public class CreateMojo extends AbstractMojo {
 	public void execute() throws MojoExecutionException {
 		try {
 			SwaggerProcessor processor = new SwaggerProcessor(getClassLoader(), warFile, outputFile);
-			processor.process();
+			if(packageName.isEmpty())
+			{
+				processor.process();
+			}
+			else
+			{
+				processor.process(packageName);
+			}
 		} catch (Exception e) {
 			throw new MojoExecutionException("Error generating a Swagger document.", e);
 		}

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/CreateMojo.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/CreateMojo.java
@@ -55,10 +55,16 @@ public class CreateMojo extends AbstractMojo {
 	private File warFile;
 	
 	/**
-	 * Location of the target WAR file.
+	 * Package to scan for annotation classes
 	 */
 	@Parameter(defaultValue = "", required = false)
 	private String packageName;
+	
+	/**
+	 * Package to scan for annotation classes
+	 */
+	@Parameter(defaultValue = "${project.build.directory}", required = false)
+	private String tmpPath;
 
 	/*
 	 * (non-Javadoc)
@@ -67,15 +73,13 @@ public class CreateMojo extends AbstractMojo {
 	 */
 	public void execute() throws MojoExecutionException {
 		try {
-			SwaggerProcessor processor = new SwaggerProcessor(getClassLoader(), warFile, outputFile);
+			String pName = packageName;
 			if(packageName.isEmpty())
 			{
-				processor.process();
+				pName = null;
 			}
-			else
-			{
-				processor.process(packageName);
-			}
+			SwaggerProcessor processor = new SwaggerProcessor(pName, tmpPath,getClassLoader(), warFile, outputFile);
+			processor.process();
 		} catch (Exception e) {
 			throw new MojoExecutionException("Error generating a Swagger document.", e);
 		}

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/CreateMojo.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/CreateMojo.java
@@ -55,13 +55,13 @@ public class CreateMojo extends AbstractMojo {
 	private File warFile;
 	
 	/**
-	 * Package to scan for annotation classes
+	 * The prefixes of classes to scan for annotations
 	 */
 	@Parameter(required = false)
-	private String[] packageNames = null;
+	private String[] prefixes = null;
 	
 	/**
-	 * Package to scan for annotation classes
+	 * The path the contents fo the WAR's WEB-INF\lib will temporarily be unpacked to
 	 */
 	@Parameter(defaultValue = "${project.build.directory}", required = false)
 	private String tmpPath;
@@ -73,7 +73,7 @@ public class CreateMojo extends AbstractMojo {
 	 */
 	public void execute() throws MojoExecutionException {
 		try {
-			SwaggerProcessor processor = new SwaggerProcessor(packageNames, tmpPath,getClassLoader(), warFile, outputFile);
+			SwaggerProcessor processor = new SwaggerProcessor(prefixes, tmpPath,getClassLoader(), warFile, outputFile);
 			processor.process();
 		} catch (Exception e) {
 			throw new MojoExecutionException("Error generating a Swagger document.", e);

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/CreateMojo.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/CreateMojo.java
@@ -57,8 +57,8 @@ public class CreateMojo extends AbstractMojo {
 	/**
 	 * Package to scan for annotation classes
 	 */
-	@Parameter(defaultValue = "", required = false)
-	private String packageName;
+	@Parameter(required = false)
+	private String[] packageNames = null;
 	
 	/**
 	 * Package to scan for annotation classes
@@ -73,12 +73,7 @@ public class CreateMojo extends AbstractMojo {
 	 */
 	public void execute() throws MojoExecutionException {
 		try {
-			String pName = packageName;
-			if(packageName.isEmpty())
-			{
-				pName = null;
-			}
-			SwaggerProcessor processor = new SwaggerProcessor(pName, tmpPath,getClassLoader(), warFile, outputFile);
+			SwaggerProcessor processor = new SwaggerProcessor(packageNames, tmpPath,getClassLoader(), warFile, outputFile);
 			processor.process();
 		} catch (Exception e) {
 			throw new MojoExecutionException("Error generating a Swagger document.", e);

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
@@ -25,7 +25,7 @@ public class GenerateSwaggerFile {
     private static final Logger logger = Logger.getLogger(GenerateSwaggerFile.class.getName());
 
     public static void main(String[] args) throws Exception {
-        if(args.length == 1 || args.length == 2) {
+        if(args.length == 1 || args.length == 2 || args.length >= 4) {
             File warFile = createWARFile(args[0]);
             if(warFile == null) {
                 System.exit(1);
@@ -42,34 +42,20 @@ public class GenerateSwaggerFile {
                 System.exit(1);
             }
 
-            SwaggerProcessor processor = new SwaggerProcessor(GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
-            processor.process();
+            SwaggerProcessor processor;
+            if(args.length >= 4) {
+            	String[] prefixes = new String[args.length-3];
+                for(int i=3; i<args.length; i++)
+                {
+                	prefixes[i-3] = args[i];
+                }
                 
-            logger.info("Success: Your swagger file was succcessfully generated.");
-            
-            System.exit(0);
-        }
-        else if(args.length >= 4)
-        {
-        	File warFile = createWARFile(args[0]);
-            if(warFile == null) {
-                System.exit(1);
+                processor = new SwaggerProcessor(prefixes,args[2],GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
+            } else {
+            	processor = new SwaggerProcessor(GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
             }
-            File outputFile;
-            outputFile = createOutputFile(warFile, args[1]);
-            if(outputFile == null) {
-                System.exit(1);
-            }
-            
-            String[] prefixes = new String[args.length-3];
-            for(int i=3; i<args.length; i++)
-            {
-            	prefixes[i-3] = args[i];
-            }
-            
-            SwaggerProcessor processor = new SwaggerProcessor(prefixes,args[2],GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
             processor.process();
-                
+            
             logger.info("Success: Your swagger file was succcessfully generated.");
             
             System.exit(0);
@@ -82,7 +68,7 @@ public class GenerateSwaggerFile {
     /**
     * Handle the first argument.
     * Return WAR application as a file on success
-    * Return null if failiure
+    * Return null if failure
     */
     private static File createWARFile(String argument) {
         File warFile = new File(argument);

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
@@ -61,13 +61,13 @@ public class GenerateSwaggerFile {
                 System.exit(1);
             }
             
-            String[] packageNames = new String[args.length-3];
+            String[] prefixes = new String[args.length-3];
             for(int i=3; i<args.length; i++)
             {
-            	packageNames[i-3] = args[i];
+            	prefixes[i-3] = args[i];
             }
             
-            SwaggerProcessor processor = new SwaggerProcessor(packageNames,args[2],GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
+            SwaggerProcessor processor = new SwaggerProcessor(prefixes,args[2],GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
             processor.process();
                 
             logger.info("Success: Your swagger file was succcessfully generated.");

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
@@ -49,7 +49,7 @@ public class GenerateSwaggerFile {
             
             System.exit(0);
         }
-        else if(args.length == 4)
+        else if(args.length >= 4)
         {
         	File warFile = createWARFile(args[0]);
             if(warFile == null) {
@@ -61,14 +61,20 @@ public class GenerateSwaggerFile {
                 System.exit(1);
             }
             
-            SwaggerProcessor processor = new SwaggerProcessor(args[2],args[3],GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
+            String[] packageNames = new String[args.length-3];
+            for(int i=3; i<args.length; i++)
+            {
+            	packageNames[i-3] = args[i];
+            }
+            
+            SwaggerProcessor processor = new SwaggerProcessor(packageNames,args[2],GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
             processor.process();
                 
             logger.info("Success: Your swagger file was succcessfully generated.");
             
             System.exit(0);
         }
-        logger.severe("Please provide the path of the WAR application as an argument (and optionally the name of the swagger file, package to scan and temp folder)");
+        logger.severe("Please provide the path of the WAR application as an argument (and optionally the name of the swagger file, temp folder and packages to scan)");
         System.exit(1);
     }
 

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
@@ -49,8 +49,26 @@ public class GenerateSwaggerFile {
             
             System.exit(0);
         }
-
-        logger.severe("Please provide the path of the WAR application as an argument (and optionally the name of the swagger file)");
+        else if(args.length == 3)
+        {
+        	File warFile = createWARFile(args[0]);
+            if(warFile == null) {
+                System.exit(1);
+            }
+            File outputFile;
+            outputFile = createOutputFile(warFile, args[1]);
+            if(outputFile == null) {
+                System.exit(1);
+            }
+            
+            SwaggerProcessor processor = new SwaggerProcessor(GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
+            processor.process(args[2]);
+                
+            logger.info("Success: Your swagger file was succcessfully generated.");
+            
+            System.exit(0);
+        }
+        logger.severe("Please provide the path of the WAR application as an argument (and optionally the name of the swagger file and package to scan)");
         System.exit(1);
     }
 

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/GenerateSwaggerFile.java
@@ -49,7 +49,7 @@ public class GenerateSwaggerFile {
             
             System.exit(0);
         }
-        else if(args.length == 3)
+        else if(args.length == 4)
         {
         	File warFile = createWARFile(args[0]);
             if(warFile == null) {
@@ -61,14 +61,14 @@ public class GenerateSwaggerFile {
                 System.exit(1);
             }
             
-            SwaggerProcessor processor = new SwaggerProcessor(GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
-            processor.process(args[2]);
+            SwaggerProcessor processor = new SwaggerProcessor(args[2],args[3],GenerateSwaggerFile.class.getClassLoader(), warFile, outputFile); 
+            processor.process();
                 
             logger.info("Success: Your swagger file was succcessfully generated.");
             
             System.exit(0);
         }
-        logger.severe("Please provide the path of the WAR application as an argument (and optionally the name of the swagger file and package to scan)");
+        logger.severe("Please provide the path of the WAR application as an argument (and optionally the name of the swagger file, package to scan and temp folder)");
         System.exit(1);
     }
 

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
@@ -39,6 +39,7 @@ import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.SwaggerDefinition;
 import net.wasdev.maven.plugins.swaggerdocgen.xml.Servlet;
 import net.wasdev.maven.plugins.swaggerdocgen.xml.WebApp;
@@ -249,6 +250,9 @@ public class SwaggerAnnotationsScanner {
             return true;
         }
         if (clz.getAnnotation(javax.ws.rs.Path.class) != null) {
+            return true;
+        }
+        if (clz.getAnnotation(ApiModel.class) != null) {
             return true;
         }
 

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -38,10 +37,6 @@ import java.util.zip.ZipFile;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
-
-import org.codehaus.plexus.util.FileUtils;
-
-import com.google.common.io.Files;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.SwaggerDefinition;

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
@@ -62,7 +62,7 @@ public class SwaggerAnnotationsScanner {
     	this(".",null, classLoader, warFile);
     }
     
-    public SwaggerAnnotationsScanner(String tmpPath, String packageName, ClassLoader classLoader, ZipFile warFile) throws IOException {
+    public SwaggerAnnotationsScanner(String tmpPath, String[] packageNames, ClassLoader classLoader, ZipFile warFile) throws IOException {
         this.warFile = warFile;
         
         classNames = getClassesInArchive(warFile, "WEB-INF/classes/");
@@ -73,14 +73,17 @@ public class SwaggerAnnotationsScanner {
         }
        
         
-        if(packageName != null)
+        if(packageNames != null)
         {
         	ArrayList<String> tmp = new ArrayList<String>();
         	for(String className : classNames)
         	{
-        		if(className.startsWith(packageName))
+        		for(String pName : packageNames)
         		{
-        			tmp.add(className);
+	        		if(className.startsWith(pName))
+	        		{
+	        			tmp.add(className);
+	        		}
         		}
         	}
         	classNames = tmp;

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
@@ -59,14 +59,14 @@ public class SwaggerAnnotationsScanner {
     private Path TmpJarFolder = null;
 
     public SwaggerAnnotationsScanner(ClassLoader classLoader, ZipFile warFile) throws IOException {
-    	this(null, classLoader, warFile);
+    	this(".",null, classLoader, warFile);
     }
     
-    public SwaggerAnnotationsScanner(String packageName, ClassLoader classLoader, ZipFile warFile) throws IOException {
+    public SwaggerAnnotationsScanner(String tmpPath, String packageName, ClassLoader classLoader, ZipFile warFile) throws IOException {
         this.warFile = warFile;
         
         classNames = getClassesInArchive(warFile, "WEB-INF/classes/");
-        TmpJarFolder = unpackJars(warFile);
+        TmpJarFolder = unpackJars(warFile, tmpPath);
         for(File f : TmpJarFolder.toFile().listFiles())
         {
         	classNames.addAll(getClassesInArchive(new ZipFile(f)));
@@ -192,10 +192,10 @@ public class SwaggerAnnotationsScanner {
 
     }
 
-    private Path unpackJars(ZipFile war) {
+    private Path unpackJars(ZipFile war, String tmpPath) {
         Path tmpDir = null;
         try {
-            File f = new File(".\\tmp");
+        	File f = new File(tmpPath+"\\tmp");
             f.mkdir();
             Path cwd = f.toPath();
             tmpDir = java.nio.file.Files.createTempDirectory(cwd, "jars");

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
@@ -50,355 +50,355 @@ import net.wasdev.maven.plugins.swaggerdocgen.xml.WebApp;
 
 public class SwaggerAnnotationsScanner {
 
-	private static final String JAX_RS_APPLICATION_CLASS_NAME = "javax.ws.rs.core.Application";
-	private static final String JAX_RS_APPLICATION_INIT_PARAM = "javax.ws.rs.Application";
-	private static final Logger logger = Logger.getLogger(SwaggerAnnotationsScanner.class.getName());
+    private static final String JAX_RS_APPLICATION_CLASS_NAME = "javax.ws.rs.core.Application";
+    private static final String JAX_RS_APPLICATION_INIT_PARAM = "javax.ws.rs.Application";
+    private static final Logger logger = Logger.getLogger(SwaggerAnnotationsScanner.class.getName());
 
-	private ClassLoader classLoader;
-	private WebApp webApp;
-	private Set<Class<?>> annotated;
-	private Set<Class<?>> appClasses;
-	private List<String> classNames;
-	private final ZipFile warFile;
+    private ClassLoader classLoader;
+    private WebApp webApp;
+    private Set<Class<?>> annotated;
+    private Set<Class<?>> appClasses;
+    private List<String> classNames;
+    private final ZipFile warFile;
 
-	private Path TmpJarFolder = null;
-	private URLClassLoader URLCL = null;
+    private Path TmpJarFolder = null;
+    private URLClassLoader URLCL = null;
 
-	public SwaggerAnnotationsScanner(ClassLoader classLoader, ZipFile warFile) throws IOException {
-		this.classLoader = classLoader;
-		this.warFile = warFile;
-		Enumeration<? extends ZipEntry> entries = warFile.entries();
-		classNames = new ArrayList<String>();
-		while (entries.hasMoreElements()) {
-			ZipEntry zipEntry = (ZipEntry) entries.nextElement();
-			String ename = zipEntry.getName();
-			if (ename.startsWith("WEB-INF/classes/")) {
-				if (ename.endsWith(".class")) {
-					String className = ename.substring(16, ename.length() - 6);
-					className = className.replace("/", ".");
-					classNames.add(className);
-				}
-			}
-		}
-		ZipEntry webXmlEntry = warFile.getEntry("WEB-INF/web.xml");
-		if (webXmlEntry != null) {
-			webApp = WebApp.loadWebXML(warFile.getInputStream(webXmlEntry));
-		}
-	}
+    public SwaggerAnnotationsScanner(ClassLoader classLoader, ZipFile warFile) throws IOException {
+        this.classLoader = classLoader;
+        this.warFile = warFile;
+        Enumeration<? extends ZipEntry> entries = warFile.entries();
+        classNames = new ArrayList<String>();
+        while (entries.hasMoreElements()) {
+            ZipEntry zipEntry = (ZipEntry) entries.nextElement();
+            String ename = zipEntry.getName();
+            if (ename.startsWith("WEB-INF/classes/")) {
+                if (ename.endsWith(".class")) {
+                    String className = ename.substring(16, ename.length() - 6);
+                    className = className.replace("/", ".");
+                    classNames.add(className);
+                }
+            }
+        }
+        ZipEntry webXmlEntry = warFile.getEntry("WEB-INF/web.xml");
+        if (webXmlEntry != null) {
+            webApp = WebApp.loadWebXML(warFile.getInputStream(webXmlEntry));
+        }
+    }
 
-	public Set<Class<?>> getScannedClasses() {
-		appClasses = new HashSet<Class<?>>();
-		List<Class<?>> loadedClasses = loadClasses(classNames);
-		annotated = getAnnotatedClasses(loadedClasses);
-		return Collections.unmodifiableSet(annotated);
-	}
+    public Set<Class<?>> getScannedClasses() {
+        appClasses = new HashSet<Class<?>>();
+        List<Class<?>> loadedClasses = loadClasses(classNames);
+        annotated = getAnnotatedClasses(loadedClasses);
+        return Collections.unmodifiableSet(annotated);
+    }
 
-	private Set<Class<?>> getAnnotatedClasses(List<Class<?>> classses) {
-		Set<Class<?>> annotated = new HashSet<Class<?>>();
-		for (Class<?> clazz : classses) {
-			if (isAnnotated(clazz)) {
-				annotated.add(clazz);
-			}
-			if (isAppClass(clazz)) {
-				appClasses.add(clazz);
-			}
-		}
-		return annotated;
-	}
+    private Set<Class<?>> getAnnotatedClasses(List<Class<?>> classses) {
+        Set<Class<?>> annotated = new HashSet<Class<?>>();
+        for (Class<?> clazz : classses) {
+            if (isAnnotated(clazz)) {
+                annotated.add(clazz);
+            }
+            if (isAppClass(clazz)) {
+                appClasses.add(clazz);
+            }
+        }
+        return annotated;
+    }
 
-	private List<Class<?>> loadClasses(List<String> classNames) {
-		List<Class<?>> loadedClasses = new ArrayList<Class<?>>();
-		Path jarPath = null;
-		try {
-			jarPath = unpackJars(warFile);
-			WARClassLoader cl = null;
-			if (jarPath == null) {
-				cl = new WARClassLoader(classLoader, warFile);
-			} else {
-				TmpJarFolder = jarPath;
-				URLClassLoader ucl = getURLClassLoader(jarPath, classLoader);
-				if (ucl == null) {
-					cl = new WARClassLoader(classLoader, warFile);
-					cleanupJarFolder();
-				} else {
-					URLCL = ucl;
-					cl = new WARClassLoader(ucl, warFile);
-				}
-			}
+    private List<Class<?>> loadClasses(List<String> classNames) {
+        List<Class<?>> loadedClasses = new ArrayList<Class<?>>();
+        Path jarPath = null;
+        try {
+            jarPath = unpackJars(warFile);
+            WARClassLoader cl = null;
+            if (jarPath == null) {
+                cl = new WARClassLoader(classLoader, warFile);
+            } else {
+                TmpJarFolder = jarPath;
+                URLClassLoader ucl = getURLClassLoader(jarPath, classLoader);
+                if (ucl == null) {
+                    cl = new WARClassLoader(classLoader, warFile);
+                    cleanupJarFolder();
+                } else {
+                    URLCL = ucl;
+                    cl = new WARClassLoader(ucl, warFile);
+                }
+            }
 
-			if (classNames != null && !classNames.isEmpty()) {
-				for (String className : classNames) {
-					Class<?> clz = cl.loadClass(className);
-					loadedClasses.add(clz);
-				}
-			}
-		} catch (ClassNotFoundException e) {
-			logger.finest(e.getMessage());
-		}
+            if (classNames != null && !classNames.isEmpty()) {
+                for (String className : classNames) {
+                    Class<?> clz = cl.loadClass(className);
+                    loadedClasses.add(clz);
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            logger.finest(e.getMessage());
+        }
 
-		return loadedClasses;
-	}
+        return loadedClasses;
+    }
 
-	private URLClassLoader getURLClassLoader(Path jarPath, ClassLoader cl) {
-		try {
-			ArrayList<URL> urls = new ArrayList<URL>();
-			for (File f : jarPath.toFile().listFiles()) {
-				URL url = new URL("jar:file:" + f.getAbsolutePath() + "!/");
-				urls.add(url);
-			}
+    private URLClassLoader getURLClassLoader(Path jarPath, ClassLoader cl) {
+        try {
+            ArrayList<URL> urls = new ArrayList<URL>();
+            for (File f : jarPath.toFile().listFiles()) {
+                URL url = new URL("jar:file:" + f.getAbsolutePath() + "!/");
+                urls.add(url);
+            }
 
-			URL[] urlArray = new URL[urls.size()];
-			urls.toArray(urlArray);
-			URLClassLoader urlcl = new URLClassLoader(urlArray, cl);
-			return urlcl;
-		} catch (Exception e) {
-			return null;
-		}
+            URL[] urlArray = new URL[urls.size()];
+            urls.toArray(urlArray);
+            URLClassLoader urlcl = new URLClassLoader(urlArray, cl);
+            return urlcl;
+        } catch (Exception e) {
+            return null;
+        }
 
-	}
+    }
 
-	private Path unpackJars(ZipFile war) {
-		Path tmpDir = null;
-		try {
-			File f = new File(".\\tmp");
-			f.mkdir();
-			Path cwd = f.toPath();
-			tmpDir = java.nio.file.Files.createTempDirectory(cwd, "jars");
-			Enumeration<? extends ZipEntry> entries = war.entries();
-			classNames = new ArrayList<String>();
-			while (entries.hasMoreElements()) {
-				ZipEntry zipEntry = (ZipEntry) entries.nextElement();
-				String ename = zipEntry.getName();
-				if (ename.startsWith("WEB-INF/lib/") && ename.endsWith(".jar")) {
-					InputStream is = warFile.getInputStream(zipEntry);
-					byte[] jarData = new byte[(int) zipEntry.getSize()];
-					int toRead = jarData.length;
-					int startIndex = 0;
-					while (toRead > 0) {
-						int actuallyRead = is.read(jarData, startIndex, toRead);
-						startIndex += actuallyRead;
-						toRead -= actuallyRead;
+    private Path unpackJars(ZipFile war) {
+        Path tmpDir = null;
+        try {
+            File f = new File(".\\tmp");
+            f.mkdir();
+            Path cwd = f.toPath();
+            tmpDir = java.nio.file.Files.createTempDirectory(cwd, "jars");
+            Enumeration<? extends ZipEntry> entries = war.entries();
+            classNames = new ArrayList<String>();
+            while (entries.hasMoreElements()) {
+                ZipEntry zipEntry = (ZipEntry) entries.nextElement();
+                String ename = zipEntry.getName();
+                if (ename.startsWith("WEB-INF/lib/") && ename.endsWith(".jar")) {
+                    InputStream is = warFile.getInputStream(zipEntry);
+                    byte[] jarData = new byte[(int) zipEntry.getSize()];
+                    int toRead = jarData.length;
+                    int startIndex = 0;
+                    while (toRead > 0) {
+                        int actuallyRead = is.read(jarData, startIndex, toRead);
+                        startIndex += actuallyRead;
+                        toRead -= actuallyRead;
 
-					}
-					is.close();
+                    }
+                    is.close();
 
-					String jarName = ename.substring(12, ename.length());
-					File jarPath = new File(tmpDir.toFile(), jarName);
-					FileOutputStream fos = new FileOutputStream(jarPath);
-					fos.write(jarData);
-					fos.flush();
-					fos.close();
-				}
-			}
-			return tmpDir;
-		} catch (Exception e) {
-			if (tmpDir != null) {
-				File f = tmpDir.toFile();
-				for (File tmp : f.listFiles()) {
-					tmp.delete();
-				}
-				f.delete();
-			}
-			return null;
-		}
-	}
+                    String jarName = ename.substring(12, ename.length());
+                    File jarPath = new File(tmpDir.toFile(), jarName);
+                    FileOutputStream fos = new FileOutputStream(jarPath);
+                    fos.write(jarData);
+                    fos.flush();
+                    fos.close();
+                }
+            }
+            return tmpDir;
+        } catch (Exception e) {
+            if (tmpDir != null) {
+                File f = tmpDir.toFile();
+                for (File tmp : f.listFiles()) {
+                    tmp.delete();
+                }
+                f.delete();
+            }
+            return null;
+        }
+    }
 
-	private boolean isAnnotated(Class<?> clz) {
-		if (clz.getAnnotation(Api.class) != null) {
-			return true;
-		}
-		if (clz.getAnnotation(SwaggerDefinition.class) != null) {
-			return true;
-		}
-		if (clz.getAnnotation(javax.ws.rs.Path.class) != null) {
-			return true;
-		}
+    private boolean isAnnotated(Class<?> clz) {
+        if (clz.getAnnotation(Api.class) != null) {
+            return true;
+        }
+        if (clz.getAnnotation(SwaggerDefinition.class) != null) {
+            return true;
+        }
+        if (clz.getAnnotation(javax.ws.rs.Path.class) != null) {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	private boolean isAppClass(Class<?> clz) {
-		if (Application.class.isAssignableFrom(clz)) {
-			return true;
-		}
+    private boolean isAppClass(Class<?> clz) {
+        if (Application.class.isAssignableFrom(clz)) {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	private String getUrlPatternForCoreAppServlet() {
-		// Check for this scenario
-		// <servlet>
-		// <servlet-name>javax.ws.rs.core.Application</servlet-name>
-		// </servlet>
-		// <servlet-mapping>
-		// <servlet-name>javax.ws.rs.core.Application</servlet-name>
-		// <url-pattern>/sample1/*</url-pattern>
-		// </servlet-mapping>
-		//
-		// This scenario means no sub-class of Application exists,
-		// and servlet mapping is required.
-		if (webApp != null) {
-			return webApp.getServletMapping(JAX_RS_APPLICATION_CLASS_NAME);
-		}
-		return null;
-	}
+    private String getUrlPatternForCoreAppServlet() {
+        // Check for this scenario
+        // <servlet>
+        // <servlet-name>javax.ws.rs.core.Application</servlet-name>
+        // </servlet>
+        // <servlet-mapping>
+        // <servlet-name>javax.ws.rs.core.Application</servlet-name>
+        // <url-pattern>/sample1/*</url-pattern>
+        // </servlet-mapping>
+        //
+        // This scenario means no sub-class of Application exists,
+        // and servlet mapping is required.
+        if (webApp != null) {
+            return webApp.getServletMapping(JAX_RS_APPLICATION_CLASS_NAME);
+        }
+        return null;
+    }
 
-	private String findServletMappingForApp(String appClassName) {
+    private String findServletMappingForApp(String appClassName) {
 
-		if (appClassName == null) {
-			return null;
-		}
-		if (webApp == null) {
-			return null;
-		}
+        if (appClassName == null) {
+            return null;
+        }
+        if (webApp == null) {
+            return null;
+        }
 
-		// Check for this scenario
-		// <servlet>
-		// <servlet-name>apps.MyApp</servlet-name>
-		// </servlet>
-		// servlet-mapping or @ApplicationPath is needed
+        // Check for this scenario
+        // <servlet>
+        // <servlet-name>apps.MyApp</servlet-name>
+        // </servlet>
+        // servlet-mapping or @ApplicationPath is needed
 
-		Servlet servlet = webApp.getServlet(appClassName);
-		if (servlet != null) {
-			logger.finest("Found servlet using servlet-name: " + appClassName);
-			return webApp.getServletMapping(servlet.getName());
-		}
+        Servlet servlet = webApp.getServlet(appClassName);
+        if (servlet != null) {
+            logger.finest("Found servlet using servlet-name: " + appClassName);
+            return webApp.getServletMapping(servlet.getName());
+        }
 
-		// Check each servlet for 2 scenarios
-		List<Servlet> servlets = webApp.getServlets();
-		if (servlets != null) {
-			for (Servlet srvlet : servlets) {
-				// Check if <servlet-class> is application
-				String servletClass = srvlet.getServletClass();
-				if (servletClass != null && servletClass.equals(appClassName)) {
-					logger.finest("Found servlet using servlet-class");
-					return webApp.getServletMapping(srvlet.getName());
-				}
-				// check if application is specified through init-param
-				String initParam = srvlet.getInitParamValue(JAX_RS_APPLICATION_INIT_PARAM);
-				if (initParam != null && initParam.equals(appClassName)) {
-					logger.finest("Found servlet using init-param");
-					return webApp.getServletMapping(srvlet.getName());
-				}
+        // Check each servlet for 2 scenarios
+        List<Servlet> servlets = webApp.getServlets();
+        if (servlets != null) {
+            for (Servlet srvlet : servlets) {
+                // Check if <servlet-class> is application
+                String servletClass = srvlet.getServletClass();
+                if (servletClass != null && servletClass.equals(appClassName)) {
+                    logger.finest("Found servlet using servlet-class");
+                    return webApp.getServletMapping(srvlet.getName());
+                }
+                // check if application is specified through init-param
+                String initParam = srvlet.getInitParamValue(JAX_RS_APPLICATION_INIT_PARAM);
+                if (initParam != null && initParam.equals(appClassName)) {
+                    logger.finest("Found servlet using init-param");
+                    return webApp.getServletMapping(srvlet.getName());
+                }
 
-			}
-		}
-		logger.finest("Didn't find servlet mapping in web.xml for " + appClassName);
-		return null;
-	}
+            }
+        }
+        logger.finest("Didn't find servlet mapping in web.xml for " + appClassName);
+        return null;
+    }
 
-	public Object getUrlMapping() {
+    public Object getUrlMapping() {
 
-		final Set<Class<?>> appClasses = this.appClasses;
-		final int size = appClasses.size();
+        final Set<Class<?>> appClasses = this.appClasses;
+        final int size = appClasses.size();
 
-		if (size < 2) {
-			String urlMapping = null;
-			if (size == 0) {
-				urlMapping = getUrlPatternForCoreAppServlet();
-			} else {
-				Class<?> appClass = appClasses.iterator().next();
-				urlMapping = findServletMappingForApp(appClass.getName());
-				if (urlMapping == null) {
-					urlMapping = getURLMappingFromApplication(appClass);
-				}
-			}
-			return urlMapping;
-		} else {
-			// Mapping between operation paths and URLs.
-			final Map<String, String> urlMappings = new HashMap<String, String>();
-			final Set<String> allOperationPaths = new HashSet<String>();
-			for (Class<?> appClass : appClasses) {
-				String urlMapping = findServletMappingForApp(appClass.getName());
-				if (urlMapping == null) {
-					urlMapping = getURLMappingFromApplication(appClass);
-				}
-				if (urlMapping == null) {
-					continue;
-				}
-				Set<Class<?>> classes = getClassesFromApplication(appClass);
-				if (classes != null) {
-					for (Class<?> cls : classes) {
-						Set<String> operationPaths = JAXRSAnnotationsUtil.getOperationPaths(cls);
-						if (!allOperationPaths.isEmpty()) {
-							for (String operationPath : operationPaths) {
-								// More than one operation has the same operation path.
-								// Only support a mix of applications that have unique
-								// 1-n mappings between URLs and operation paths for now.
-								if (allOperationPaths.contains(operationPath)) {
-									return null;
-								}
-								allOperationPaths.add(operationPath);
-								urlMappings.put(operationPath, urlMapping);
-							}
-						} else {
-							allOperationPaths.addAll(operationPaths);
-						}
-					}
-				}
-			}
-			return urlMappings;
-		}
-	}
+        if (size < 2) {
+            String urlMapping = null;
+            if (size == 0) {
+                urlMapping = getUrlPatternForCoreAppServlet();
+            } else {
+                Class<?> appClass = appClasses.iterator().next();
+                urlMapping = findServletMappingForApp(appClass.getName());
+                if (urlMapping == null) {
+                    urlMapping = getURLMappingFromApplication(appClass);
+                }
+            }
+            return urlMapping;
+        } else {
+            // Mapping between operation paths and URLs.
+            final Map<String, String> urlMappings = new HashMap<String, String>();
+            final Set<String> allOperationPaths = new HashSet<String>();
+            for (Class<?> appClass : appClasses) {
+                String urlMapping = findServletMappingForApp(appClass.getName());
+                if (urlMapping == null) {
+                    urlMapping = getURLMappingFromApplication(appClass);
+                }
+                if (urlMapping == null) {
+                    continue;
+                }
+                Set<Class<?>> classes = getClassesFromApplication(appClass);
+                if (classes != null) {
+                    for (Class<?> cls : classes) {
+                        Set<String> operationPaths = JAXRSAnnotationsUtil.getOperationPaths(cls);
+                        if (!allOperationPaths.isEmpty()) {
+                            for (String operationPath : operationPaths) {
+                                // More than one operation has the same operation path.
+                                // Only support a mix of applications that have unique
+                                // 1-n mappings between URLs and operation paths for now.
+                                if (allOperationPaths.contains(operationPath)) {
+                                    return null;
+                                }
+                                allOperationPaths.add(operationPath);
+                                urlMappings.put(operationPath, urlMapping);
+                            }
+                        } else {
+                            allOperationPaths.addAll(operationPaths);
+                        }
+                    }
+                }
+            }
+            return urlMappings;
+        }
+    }
 
-	private String getURLMappingFromApplication(Class<?> appClass) {
-		ApplicationPath apath = appClass.getAnnotation(ApplicationPath.class);
-		if (apath != null) {
-			String urlMapping = apath.value();
-			if (urlMapping == null || urlMapping.isEmpty() || urlMapping.equals("/")) {
-				return "";
-			}
-			if (urlMapping != null && !urlMapping.startsWith("/")) {
-				urlMapping = "/" + urlMapping;
-			}
-			return urlMapping;
-		} else {
-			logger.finest("Didn't find @ApplicationPath in Application classs " + appClass.getName());
-		}
-		return null;
-	}
+    private String getURLMappingFromApplication(Class<?> appClass) {
+        ApplicationPath apath = appClass.getAnnotation(ApplicationPath.class);
+        if (apath != null) {
+            String urlMapping = apath.value();
+            if (urlMapping == null || urlMapping.isEmpty() || urlMapping.equals("/")) {
+                return "";
+            }
+            if (urlMapping != null && !urlMapping.startsWith("/")) {
+                urlMapping = "/" + urlMapping;
+            }
+            return urlMapping;
+        } else {
+            logger.finest("Didn't find @ApplicationPath in Application classs " + appClass.getName());
+        }
+        return null;
+    }
 
-	public Set<Class<?>> getClassesFromApplication(Class<?> appClass) {
-		try {
-			if (!Application.class.isAssignableFrom(appClass)) {
-				return null;
-			}
-			Application app = (Application) appClass.newInstance();
-			Set<Class<?>> clss = app.getClasses();
-			Set<Object> singletons = app.getSingletons();
-			HashSet<Class<?>> classes = new HashSet<Class<?>>();
-			for (Class<?> cls : clss) {
-				classes.add(cls);
-			}
-			for (Object singleton : singletons) {
-				classes.add(singleton.getClass());
-			}
-			return classes;
-		} catch (IllegalAccessException e) {
-			logger.finest("Failed to initialize Application: " + appClass.getName() + ": " + e.getMessage());
-		} catch (InstantiationException e) {
-			logger.finest("Failed to initialize Application: " + appClass.getName() + ": " + e.getMessage());
-		}
-		return null;
-	}
+    public Set<Class<?>> getClassesFromApplication(Class<?> appClass) {
+        try {
+            if (!Application.class.isAssignableFrom(appClass)) {
+                return null;
+            }
+            Application app = (Application) appClass.newInstance();
+            Set<Class<?>> clss = app.getClasses();
+            Set<Object> singletons = app.getSingletons();
+            HashSet<Class<?>> classes = new HashSet<Class<?>>();
+            for (Class<?> cls : clss) {
+                classes.add(cls);
+            }
+            for (Object singleton : singletons) {
+                classes.add(singleton.getClass());
+            }
+            return classes;
+        } catch (IllegalAccessException e) {
+            logger.finest("Failed to initialize Application: " + appClass.getName() + ": " + e.getMessage());
+        } catch (InstantiationException e) {
+            logger.finest("Failed to initialize Application: " + appClass.getName() + ": " + e.getMessage());
+        }
+        return null;
+    }
 
-	public void cleanupJarFolder() {
-		if (URLCL != null) {
-			try {
-				URLCL.close();
+    public void cleanupJarFolder() {
+        if (URLCL != null) {
+            try {
+                URLCL.close();
 
-			} catch (IOException e) {
-				logger.info(String.format(
-						"Could not close URLClassLoader. Temp folder %s might not be deleted automatically. You can delete it manually",
-						TmpJarFolder.toFile().getAbsolutePath()));
-			}
-		}
-		if (TmpJarFolder != null) {
-			File f = TmpJarFolder.toFile();
-			for (File tmp : f.listFiles()) {
-				tmp.deleteOnExit();
-			}
-			f.deleteOnExit();
-		}
-	}
+            } catch (IOException e) {
+                logger.info(String.format(
+                        "Could not close URLClassLoader. Temp folder %s might not be deleted automatically. You can delete it manually",
+                        TmpJarFolder.toFile().getAbsolutePath()));
+            }
+        }
+        if (TmpJarFolder != null) {
+            File f = TmpJarFolder.toFile();
+            for (File tmp : f.listFiles()) {
+                tmp.deleteOnExit();
+            }
+            f.deleteOnExit();
+        }
+    }
 }

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
@@ -45,7 +45,7 @@ import net.wasdev.maven.plugins.swaggerdocgen.xml.Servlet;
 import net.wasdev.maven.plugins.swaggerdocgen.xml.WebApp;
 
 public class SwaggerAnnotationsScanner {
-
+    
     private static final String JAX_RS_APPLICATION_CLASS_NAME = "javax.ws.rs.core.Application";
     private static final String JAX_RS_APPLICATION_INIT_PARAM = "javax.ws.rs.Application";
     private static final Logger logger = Logger.getLogger(SwaggerAnnotationsScanner.class.getName());
@@ -138,8 +138,7 @@ public class SwaggerAnnotationsScanner {
         
         return clsNames;
     }
-    
-    
+
     public Set<Class<?>> getScannedClasses() {
         appClasses = new HashSet<Class<?>>();
         List<Class<?>> loadedClasses = loadClasses(classNames);
@@ -173,7 +172,6 @@ public class SwaggerAnnotationsScanner {
         } catch (ClassNotFoundException e) {
             logger.finest(e.getMessage());
         }
-
         return loadedClasses;
     }
 
@@ -329,15 +327,16 @@ public class SwaggerAnnotationsScanner {
     }
 
     public Object getUrlMapping() {
-
+        
         final Set<Class<?>> appClasses = this.appClasses;
         final int size = appClasses.size();
-
+        
         if (size < 2) {
             String urlMapping = null;
             if (size == 0) {
                 urlMapping = getUrlPatternForCoreAppServlet();
-            } else {
+            } 
+            else {
                 Class<?> appClass = appClasses.iterator().next();
                 urlMapping = findServletMappingForApp(appClass.getName());
                 if (urlMapping == null) {
@@ -345,7 +344,8 @@ public class SwaggerAnnotationsScanner {
                 }
             }
             return urlMapping;
-        } else {
+        }
+        else {
             // Mapping between operation paths and URLs.
             final Map<String, String> urlMappings = new HashMap<String, String>();
             final Set<String> allOperationPaths = new HashSet<String>();
@@ -372,7 +372,8 @@ public class SwaggerAnnotationsScanner {
                                 allOperationPaths.add(operationPath);
                                 urlMappings.put(operationPath, urlMapping);
                             }
-                        } else {
+                        }
+                        else {
                             allOperationPaths.addAll(operationPaths);
                         }
                     }
@@ -381,7 +382,7 @@ public class SwaggerAnnotationsScanner {
             return urlMappings;
         }
     }
-
+    
     private String getURLMappingFromApplication(Class<?> appClass) {
         ApplicationPath apath = appClass.getAnnotation(ApplicationPath.class);
         if (apath != null) {
@@ -393,12 +394,13 @@ public class SwaggerAnnotationsScanner {
                 urlMapping = "/" + urlMapping;
             }
             return urlMapping;
-        } else {
+        } 
+        else {
             logger.finest("Didn't find @ApplicationPath in Application classs " + appClass.getName());
         }
         return null;
     }
-
+    
     public Set<Class<?>> getClassesFromApplication(Class<?> appClass) {
         try {
             if (!Application.class.isAssignableFrom(appClass)) {

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
@@ -63,7 +63,7 @@ public class SwaggerAnnotationsScanner {
     	this(".",null, classLoader, warFile);
     }
     
-    public SwaggerAnnotationsScanner(String tmpPath, String[] packageNames, ClassLoader classLoader, ZipFile warFile) throws IOException {
+    public SwaggerAnnotationsScanner(String tmpPath, String[] prefixes, ClassLoader classLoader, ZipFile warFile) throws IOException {
         this.warFile = warFile;
         
         classNames = getClassesInArchive(warFile, "WEB-INF/classes/");
@@ -73,13 +73,12 @@ public class SwaggerAnnotationsScanner {
         	classNames.addAll(getClassesInArchive(new ZipFile(f)));
         }
        
-        
-        if(packageNames != null)
+        if(prefixes != null)
         {
         	ArrayList<String> tmp = new ArrayList<String>();
         	for(String className : classNames)
         	{
-        		for(String pName : packageNames)
+        		for(String pName : prefixes)
         		{
 	        		if(className.startsWith(pName))
 	        		{

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerAnnotationsScanner.java
@@ -49,380 +49,356 @@ import net.wasdev.maven.plugins.swaggerdocgen.xml.Servlet;
 import net.wasdev.maven.plugins.swaggerdocgen.xml.WebApp;
 
 public class SwaggerAnnotationsScanner {
-    
-    private static final String JAX_RS_APPLICATION_CLASS_NAME = "javax.ws.rs.core.Application";
-    private static final String JAX_RS_APPLICATION_INIT_PARAM = "javax.ws.rs.Application";
-    private static final Logger logger = Logger.getLogger(SwaggerAnnotationsScanner.class.getName());
 
-    private ClassLoader classLoader;
-    private WebApp webApp;
-    private Set<Class<?>> annotated;
-    private Set<Class<?>> appClasses;
-    private List<String> classNames;
-    private final ZipFile warFile;
-    
-    private Path TmpJarFolder = null;
-    private URLClassLoader URLCL = null;
+	private static final String JAX_RS_APPLICATION_CLASS_NAME = "javax.ws.rs.core.Application";
+	private static final String JAX_RS_APPLICATION_INIT_PARAM = "javax.ws.rs.Application";
+	private static final Logger logger = Logger.getLogger(SwaggerAnnotationsScanner.class.getName());
 
-    public SwaggerAnnotationsScanner(ClassLoader classLoader, ZipFile warFile) throws IOException {
-        this.classLoader = classLoader;
-        this.warFile = warFile;
-        Enumeration<? extends ZipEntry> entries = warFile.entries();
-        classNames = new ArrayList<String>();
-        while (entries.hasMoreElements()) {
-            ZipEntry zipEntry = (ZipEntry) entries.nextElement();
-            String ename = zipEntry.getName();
-            if (ename.startsWith("WEB-INF/classes/")) {
-                if (ename.endsWith(".class")) {
-                    String className = ename.substring(16, ename.length() - 6);
-                    className = className.replace("/", ".");
-                    classNames.add(className);
-                }
-            }
-        }
-        ZipEntry webXmlEntry = warFile.getEntry("WEB-INF/web.xml");
-        if (webXmlEntry != null) {
-            webApp = WebApp.loadWebXML(warFile.getInputStream(webXmlEntry));
-        }
-    }
+	private ClassLoader classLoader;
+	private WebApp webApp;
+	private Set<Class<?>> annotated;
+	private Set<Class<?>> appClasses;
+	private List<String> classNames;
+	private final ZipFile warFile;
 
-    public Set<Class<?>> getScannedClasses() {
-        appClasses = new HashSet<Class<?>>();
-        List<Class<?>> loadedClasses = loadClasses(classNames);
-        annotated = getAnnotatedClasses(loadedClasses);
-        return Collections.unmodifiableSet(annotated);
-    }
+	private Path TmpJarFolder = null;
+	private URLClassLoader URLCL = null;
 
-    private Set<Class<?>> getAnnotatedClasses(List<Class<?>> classses) {
-        Set<Class<?>> annotated = new HashSet<Class<?>>();
-        for (Class<?> clazz : classses) {
-            if (isAnnotated(clazz)) {
-                annotated.add(clazz);
-            }
-            if (isAppClass(clazz)) {
-                appClasses.add(clazz);
-            }
-        }
-        return annotated;
-    }
+	public SwaggerAnnotationsScanner(ClassLoader classLoader, ZipFile warFile) throws IOException {
+		this.classLoader = classLoader;
+		this.warFile = warFile;
+		Enumeration<? extends ZipEntry> entries = warFile.entries();
+		classNames = new ArrayList<String>();
+		while (entries.hasMoreElements()) {
+			ZipEntry zipEntry = (ZipEntry) entries.nextElement();
+			String ename = zipEntry.getName();
+			if (ename.startsWith("WEB-INF/classes/")) {
+				if (ename.endsWith(".class")) {
+					String className = ename.substring(16, ename.length() - 6);
+					className = className.replace("/", ".");
+					classNames.add(className);
+				}
+			}
+		}
+		ZipEntry webXmlEntry = warFile.getEntry("WEB-INF/web.xml");
+		if (webXmlEntry != null) {
+			webApp = WebApp.loadWebXML(warFile.getInputStream(webXmlEntry));
+		}
+	}
 
-    private List<Class<?>> loadClasses(List<String> classNames) {
-        List<Class<?>> loadedClasses = new ArrayList<Class<?>>();
-        Path jarPath = null;
-        try {
-        	jarPath = unpackJars(warFile);
-        	WARClassLoader cl = null;
-        	if(jarPath == null)
-        	{
-        		cl = new WARClassLoader(classLoader, warFile);
-        	}
-        	else
-        	{
-        		TmpJarFolder = jarPath;
-        		URLClassLoader ucl = getURLClassLoader(jarPath, classLoader);
-        		if(ucl == null)
-        		{
-        			cl = new WARClassLoader(classLoader, warFile);
-        			cleanupJarFolder();
-        		}
-        		else
-        		{
-        			URLCL = ucl;
-        			cl = new WARClassLoader(ucl, warFile);
-        		}
-        	}
-            
-            if (classNames != null && !classNames.isEmpty()) {
-                for (String className : classNames) {
-                    Class<?> clz = cl.loadClass(className);
-                    loadedClasses.add(clz);
-                }
-            }
-        } catch (ClassNotFoundException e) {
-            logger.finest(e.getMessage());
-        }
-        
-        return loadedClasses;
-    }
+	public Set<Class<?>> getScannedClasses() {
+		appClasses = new HashSet<Class<?>>();
+		List<Class<?>> loadedClasses = loadClasses(classNames);
+		annotated = getAnnotatedClasses(loadedClasses);
+		return Collections.unmodifiableSet(annotated);
+	}
 
-    private URLClassLoader getURLClassLoader(Path jarPath, ClassLoader cl) {
-		try
-		{
-	    	ArrayList<URL> urls = new ArrayList<URL>();
-			for(File f : jarPath.toFile().listFiles())
-			{
-				URL url = new URL("jar:file:"+f.getAbsolutePath() + "!/");
+	private Set<Class<?>> getAnnotatedClasses(List<Class<?>> classses) {
+		Set<Class<?>> annotated = new HashSet<Class<?>>();
+		for (Class<?> clazz : classses) {
+			if (isAnnotated(clazz)) {
+				annotated.add(clazz);
+			}
+			if (isAppClass(clazz)) {
+				appClasses.add(clazz);
+			}
+		}
+		return annotated;
+	}
+
+	private List<Class<?>> loadClasses(List<String> classNames) {
+		List<Class<?>> loadedClasses = new ArrayList<Class<?>>();
+		Path jarPath = null;
+		try {
+			jarPath = unpackJars(warFile);
+			WARClassLoader cl = null;
+			if (jarPath == null) {
+				cl = new WARClassLoader(classLoader, warFile);
+			} else {
+				TmpJarFolder = jarPath;
+				URLClassLoader ucl = getURLClassLoader(jarPath, classLoader);
+				if (ucl == null) {
+					cl = new WARClassLoader(classLoader, warFile);
+					cleanupJarFolder();
+				} else {
+					URLCL = ucl;
+					cl = new WARClassLoader(ucl, warFile);
+				}
+			}
+
+			if (classNames != null && !classNames.isEmpty()) {
+				for (String className : classNames) {
+					Class<?> clz = cl.loadClass(className);
+					loadedClasses.add(clz);
+				}
+			}
+		} catch (ClassNotFoundException e) {
+			logger.finest(e.getMessage());
+		}
+
+		return loadedClasses;
+	}
+
+	private URLClassLoader getURLClassLoader(Path jarPath, ClassLoader cl) {
+		try {
+			ArrayList<URL> urls = new ArrayList<URL>();
+			for (File f : jarPath.toFile().listFiles()) {
+				URL url = new URL("jar:file:" + f.getAbsolutePath() + "!/");
 				urls.add(url);
 			}
-			
+
 			URL[] urlArray = new URL[urls.size()];
 			urls.toArray(urlArray);
 			URLClassLoader urlcl = new URLClassLoader(urlArray, cl);
 			return urlcl;
-		}
-		catch(Exception e)
-		{
+		} catch (Exception e) {
 			return null;
 		}
-		
-		
+
 	}
 
-	private Path unpackJars(ZipFile war)
-    {
+	private Path unpackJars(ZipFile war) {
 		Path tmpDir = null;
-    	try
-    	{
-    		File f = new File(".\\tmp");
-    		f.mkdir();
-    		Path cwd = f.toPath();
-	    	tmpDir = java.nio.file.Files.createTempDirectory(cwd,"jars");
-	    	Enumeration<? extends ZipEntry> entries = war.entries();
-	        classNames = new ArrayList<String>();
-	        while (entries.hasMoreElements()) {
-	            ZipEntry zipEntry = (ZipEntry) entries.nextElement();
-	            String ename = zipEntry.getName();
-	            if (ename.startsWith("WEB-INF/lib/") && ename.endsWith(".jar")) {
+		try {
+			File f = new File(".\\tmp");
+			f.mkdir();
+			Path cwd = f.toPath();
+			tmpDir = java.nio.file.Files.createTempDirectory(cwd, "jars");
+			Enumeration<? extends ZipEntry> entries = war.entries();
+			classNames = new ArrayList<String>();
+			while (entries.hasMoreElements()) {
+				ZipEntry zipEntry = (ZipEntry) entries.nextElement();
+				String ename = zipEntry.getName();
+				if (ename.startsWith("WEB-INF/lib/") && ename.endsWith(".jar")) {
 					InputStream is = warFile.getInputStream(zipEntry);
 					byte[] jarData = new byte[(int) zipEntry.getSize()];
 					int toRead = jarData.length;
 					int startIndex = 0;
-					while(toRead > 0)
-					{
+					while (toRead > 0) {
 						int actuallyRead = is.read(jarData, startIndex, toRead);
 						startIndex += actuallyRead;
 						toRead -= actuallyRead;
-						
+
 					}
 					is.close();
-					
+
 					String jarName = ename.substring(12, ename.length());
-					File jarPath =  new File(tmpDir.toFile(), jarName);
+					File jarPath = new File(tmpDir.toFile(), jarName);
 					FileOutputStream fos = new FileOutputStream(jarPath);
 					fos.write(jarData);
 					fos.flush();
 					fos.close();
-	            }
-	        }
-	        return tmpDir;
-    	}
-    	catch(Exception e)
-    	{
-    		if(tmpDir != null)
-    		{
-    			File f = tmpDir.toFile();
-    			for(File tmp : f.listFiles())
-    			{
-    				tmp.delete();
-    			}
-    			f.delete();
-    		}
-    		return null;
-    	}
- 	}
+				}
+			}
+			return tmpDir;
+		} catch (Exception e) {
+			if (tmpDir != null) {
+				File f = tmpDir.toFile();
+				for (File tmp : f.listFiles()) {
+					tmp.delete();
+				}
+				f.delete();
+			}
+			return null;
+		}
+	}
 
 	private boolean isAnnotated(Class<?> clz) {
-        if (clz.getAnnotation(Api.class) != null) {
-            return true;
-        }
-        if (clz.getAnnotation(SwaggerDefinition.class) != null) {
-            return true;
-        }
-        if (clz.getAnnotation(javax.ws.rs.Path.class) != null) {
-            return true;
-        }
+		if (clz.getAnnotation(Api.class) != null) {
+			return true;
+		}
+		if (clz.getAnnotation(SwaggerDefinition.class) != null) {
+			return true;
+		}
+		if (clz.getAnnotation(javax.ws.rs.Path.class) != null) {
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    private boolean isAppClass(Class<?> clz) {
-        if (Application.class.isAssignableFrom(clz)) {
-            return true;
-        }
+	private boolean isAppClass(Class<?> clz) {
+		if (Application.class.isAssignableFrom(clz)) {
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    private String getUrlPatternForCoreAppServlet() {
-        // Check for this scenario
-        // <servlet>
-        // <servlet-name>javax.ws.rs.core.Application</servlet-name>
-        // </servlet>
-        // <servlet-mapping>
-        // <servlet-name>javax.ws.rs.core.Application</servlet-name>
-        // <url-pattern>/sample1/*</url-pattern>
-        // </servlet-mapping>
-        //
-        // This scenario means no sub-class of Application exists,
-        // and servlet mapping is required.
-        if (webApp != null) {
-            return webApp.getServletMapping(JAX_RS_APPLICATION_CLASS_NAME);
-        }
-        return null;
-    }
+	private String getUrlPatternForCoreAppServlet() {
+		// Check for this scenario
+		// <servlet>
+		// <servlet-name>javax.ws.rs.core.Application</servlet-name>
+		// </servlet>
+		// <servlet-mapping>
+		// <servlet-name>javax.ws.rs.core.Application</servlet-name>
+		// <url-pattern>/sample1/*</url-pattern>
+		// </servlet-mapping>
+		//
+		// This scenario means no sub-class of Application exists,
+		// and servlet mapping is required.
+		if (webApp != null) {
+			return webApp.getServletMapping(JAX_RS_APPLICATION_CLASS_NAME);
+		}
+		return null;
+	}
 
-    private String findServletMappingForApp(String appClassName) {
+	private String findServletMappingForApp(String appClassName) {
 
-        if (appClassName == null) {
-            return null;
-        }
-        if (webApp == null) {
-            return null;
-        }
+		if (appClassName == null) {
+			return null;
+		}
+		if (webApp == null) {
+			return null;
+		}
 
-        // Check for this scenario
-        // <servlet>
-        // <servlet-name>apps.MyApp</servlet-name>
-        // </servlet>
-        // servlet-mapping or @ApplicationPath is needed
+		// Check for this scenario
+		// <servlet>
+		// <servlet-name>apps.MyApp</servlet-name>
+		// </servlet>
+		// servlet-mapping or @ApplicationPath is needed
 
-        Servlet servlet = webApp.getServlet(appClassName);
-        if (servlet != null) {
-            logger.finest("Found servlet using servlet-name: " + appClassName);
-            return webApp.getServletMapping(servlet.getName());
-        }
+		Servlet servlet = webApp.getServlet(appClassName);
+		if (servlet != null) {
+			logger.finest("Found servlet using servlet-name: " + appClassName);
+			return webApp.getServletMapping(servlet.getName());
+		}
 
-        // Check each servlet for 2 scenarios
-        List<Servlet> servlets = webApp.getServlets();
-        if (servlets != null) {
-            for (Servlet srvlet : servlets) {
-                // Check if <servlet-class> is application
-                String servletClass = srvlet.getServletClass();
-                if (servletClass != null && servletClass.equals(appClassName)) {
-                    logger.finest("Found servlet using servlet-class");
-                    return webApp.getServletMapping(srvlet.getName());
-                }
-                // check if application is specified through init-param
-                String initParam = srvlet.getInitParamValue(JAX_RS_APPLICATION_INIT_PARAM);
-                if (initParam != null && initParam.equals(appClassName)) {
-                    logger.finest("Found servlet using init-param");
-                    return webApp.getServletMapping(srvlet.getName());
-                }
+		// Check each servlet for 2 scenarios
+		List<Servlet> servlets = webApp.getServlets();
+		if (servlets != null) {
+			for (Servlet srvlet : servlets) {
+				// Check if <servlet-class> is application
+				String servletClass = srvlet.getServletClass();
+				if (servletClass != null && servletClass.equals(appClassName)) {
+					logger.finest("Found servlet using servlet-class");
+					return webApp.getServletMapping(srvlet.getName());
+				}
+				// check if application is specified through init-param
+				String initParam = srvlet.getInitParamValue(JAX_RS_APPLICATION_INIT_PARAM);
+				if (initParam != null && initParam.equals(appClassName)) {
+					logger.finest("Found servlet using init-param");
+					return webApp.getServletMapping(srvlet.getName());
+				}
 
-            }
-        }
-        logger.finest("Didn't find servlet mapping in web.xml for " + appClassName);
-        return null;
-    }
-
-    public Object getUrlMapping() {
-        
-        final Set<Class<?>> appClasses = this.appClasses;
-        final int size = appClasses.size();
-        
-        if (size < 2) {
-            String urlMapping = null;
-            if (size == 0) {
-                urlMapping = getUrlPatternForCoreAppServlet();
-            } 
-            else {
-                Class<?> appClass = appClasses.iterator().next();
-                urlMapping = findServletMappingForApp(appClass.getName());
-                if (urlMapping == null) {
-                    urlMapping = getURLMappingFromApplication(appClass);
-                }
-            }
-            return urlMapping;
-        }
-        else {
-            // Mapping between operation paths and URLs.
-            final Map<String, String> urlMappings = new HashMap<String, String>();
-            final Set<String> allOperationPaths = new HashSet<String>();
-            for (Class<?> appClass : appClasses) {
-                String urlMapping = findServletMappingForApp(appClass.getName());
-                if (urlMapping == null) {
-                    urlMapping = getURLMappingFromApplication(appClass);
-                }
-                if (urlMapping == null) {
-                    continue;
-                }
-                Set<Class<?>> classes = getClassesFromApplication(appClass);
-                if (classes != null) {
-                    for (Class<?> cls : classes) {
-                        Set<String> operationPaths = JAXRSAnnotationsUtil.getOperationPaths(cls);
-                        if (!allOperationPaths.isEmpty()) {
-                            for (String operationPath : operationPaths) {
-                                // More than one operation has the same operation path.
-                                // Only support a mix of applications that have unique
-                                // 1-n mappings between URLs and operation paths for now.
-                                if (allOperationPaths.contains(operationPath)) {
-                                    return null;
-                                }
-                                allOperationPaths.add(operationPath);
-                                urlMappings.put(operationPath, urlMapping);
-                            }
-                        }
-                        else {
-                            allOperationPaths.addAll(operationPaths);
-                        }
-                    }
-                }
-            }
-            return urlMappings;
-        }
-    }
-    
-    private String getURLMappingFromApplication(Class<?> appClass) {
-        ApplicationPath apath = appClass.getAnnotation(ApplicationPath.class);
-        if (apath != null) {
-            String urlMapping = apath.value();
-            if (urlMapping == null || urlMapping.isEmpty() || urlMapping.equals("/")) {
-                return "";
-            }
-            if (urlMapping != null && !urlMapping.startsWith("/")) {
-                urlMapping = "/" + urlMapping;
-            }
-            return urlMapping;
-        } 
-        else {
-            logger.finest("Didn't find @ApplicationPath in Application classs " + appClass.getName());
-        }
-        return null;
-    }
-    
-    public Set<Class<?>> getClassesFromApplication(Class<?> appClass) {
-        try {
-            if (!Application.class.isAssignableFrom(appClass)) {
-                return null;
-            }
-            Application app = (Application) appClass.newInstance();
-            Set<Class<?>> clss = app.getClasses();
-            Set<Object> singletons = app.getSingletons();
-            HashSet<Class<?>> classes = new HashSet<Class<?>>();
-            for (Class<?> cls : clss) {
-                classes.add(cls);
-            }
-            for (Object singleton : singletons) {
-                classes.add(singleton.getClass());
-            }
-            return classes;
-        } catch (IllegalAccessException e) {
-            logger.finest("Failed to initialize Application: " + appClass.getName() + ": " + e.getMessage());
-        } catch (InstantiationException e) {
-            logger.finest("Failed to initialize Application: " + appClass.getName() + ": " + e.getMessage());
-        }
-        return null;
-    }
-    
-    public void cleanupJarFolder()
-    {
-    	if(URLCL != null)
-    	{
-    		try {
-				URLCL.close();
-				
-			} catch (IOException e) {
-				logger.info(String.format("Could not close URLClassLoader. Temp folder %s might not be deleted automatically. You can delete it manually", TmpJarFolder.toFile().getAbsolutePath()));
 			}
-    	}
-    	if(TmpJarFolder != null)
-    	{
+		}
+		logger.finest("Didn't find servlet mapping in web.xml for " + appClassName);
+		return null;
+	}
+
+	public Object getUrlMapping() {
+
+		final Set<Class<?>> appClasses = this.appClasses;
+		final int size = appClasses.size();
+
+		if (size < 2) {
+			String urlMapping = null;
+			if (size == 0) {
+				urlMapping = getUrlPatternForCoreAppServlet();
+			} else {
+				Class<?> appClass = appClasses.iterator().next();
+				urlMapping = findServletMappingForApp(appClass.getName());
+				if (urlMapping == null) {
+					urlMapping = getURLMappingFromApplication(appClass);
+				}
+			}
+			return urlMapping;
+		} else {
+			// Mapping between operation paths and URLs.
+			final Map<String, String> urlMappings = new HashMap<String, String>();
+			final Set<String> allOperationPaths = new HashSet<String>();
+			for (Class<?> appClass : appClasses) {
+				String urlMapping = findServletMappingForApp(appClass.getName());
+				if (urlMapping == null) {
+					urlMapping = getURLMappingFromApplication(appClass);
+				}
+				if (urlMapping == null) {
+					continue;
+				}
+				Set<Class<?>> classes = getClassesFromApplication(appClass);
+				if (classes != null) {
+					for (Class<?> cls : classes) {
+						Set<String> operationPaths = JAXRSAnnotationsUtil.getOperationPaths(cls);
+						if (!allOperationPaths.isEmpty()) {
+							for (String operationPath : operationPaths) {
+								// More than one operation has the same operation path.
+								// Only support a mix of applications that have unique
+								// 1-n mappings between URLs and operation paths for now.
+								if (allOperationPaths.contains(operationPath)) {
+									return null;
+								}
+								allOperationPaths.add(operationPath);
+								urlMappings.put(operationPath, urlMapping);
+							}
+						} else {
+							allOperationPaths.addAll(operationPaths);
+						}
+					}
+				}
+			}
+			return urlMappings;
+		}
+	}
+
+	private String getURLMappingFromApplication(Class<?> appClass) {
+		ApplicationPath apath = appClass.getAnnotation(ApplicationPath.class);
+		if (apath != null) {
+			String urlMapping = apath.value();
+			if (urlMapping == null || urlMapping.isEmpty() || urlMapping.equals("/")) {
+				return "";
+			}
+			if (urlMapping != null && !urlMapping.startsWith("/")) {
+				urlMapping = "/" + urlMapping;
+			}
+			return urlMapping;
+		} else {
+			logger.finest("Didn't find @ApplicationPath in Application classs " + appClass.getName());
+		}
+		return null;
+	}
+
+	public Set<Class<?>> getClassesFromApplication(Class<?> appClass) {
+		try {
+			if (!Application.class.isAssignableFrom(appClass)) {
+				return null;
+			}
+			Application app = (Application) appClass.newInstance();
+			Set<Class<?>> clss = app.getClasses();
+			Set<Object> singletons = app.getSingletons();
+			HashSet<Class<?>> classes = new HashSet<Class<?>>();
+			for (Class<?> cls : clss) {
+				classes.add(cls);
+			}
+			for (Object singleton : singletons) {
+				classes.add(singleton.getClass());
+			}
+			return classes;
+		} catch (IllegalAccessException e) {
+			logger.finest("Failed to initialize Application: " + appClass.getName() + ": " + e.getMessage());
+		} catch (InstantiationException e) {
+			logger.finest("Failed to initialize Application: " + appClass.getName() + ": " + e.getMessage());
+		}
+		return null;
+	}
+
+	public void cleanupJarFolder() {
+		if (URLCL != null) {
+			try {
+				URLCL.close();
+
+			} catch (IOException e) {
+				logger.info(String.format(
+						"Could not close URLClassLoader. Temp folder %s might not be deleted automatically. You can delete it manually",
+						TmpJarFolder.toFile().getAbsolutePath()));
+			}
+		}
+		if (TmpJarFolder != null) {
 			File f = TmpJarFolder.toFile();
-			for(File tmp : f.listFiles())
-			{
+			for (File tmp : f.listFiles()) {
 				tmp.deleteOnExit();
 			}
 			f.deleteOnExit();
-    	}
-    }
+		}
+	}
 }

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
@@ -68,8 +68,7 @@ public class SwaggerProcessor {
 	
 	private static final Logger logger = Logger.getLogger(SwaggerProcessor.class.getName());
 
-	public SwaggerProcessor(ClassLoader classLoader, File warFile, File outputFile)
-	{
+	public SwaggerProcessor(ClassLoader classLoader, File warFile, File outputFile) {
 		this(null, ".", classLoader, warFile, outputFile);
 	}
 	
@@ -163,8 +162,7 @@ public class SwaggerProcessor {
 				stubPaths = swaggerStubModel.getPaths().keySet();
 			}
 			
-			for(Class<?> c : getModelClasses(classes))
-			{
+			for(Class<?> c : getModelClasses(classes)) {
 					appendModels(c, reader.getSwagger());
 			}
 			
@@ -187,10 +185,8 @@ public class SwaggerProcessor {
 
 	private Set<Class<?>> getModelClasses(Set<Class<?>> classes) {
 		Set<Class<?>> modelClasses = new HashSet<Class<?>>();
-		for(Class<?> c : classes)
-		{
-			if(c.getAnnotation(ApiModel.class) != null)
-			{
+		for(Class<?> c : classes) {
+			if(c.getAnnotation(ApiModel.class) != null) {
 				modelClasses.add(c);
 			}
 		}

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
@@ -46,213 +46,214 @@ import io.swagger.util.Json;
 import io.swagger.util.Yaml;
 
 public class SwaggerProcessor {
-
-    // Location of Swagger JSON doc in module
-    private static final String DEFAULT_SWAGGER_JSON_LOCATION = "META-INF/swagger.json";
-
-    // Location of Swagger JSON stub doc in module
-    private static final String DEFAULT_SWAGGER_JSON_STUB_LOCATION = "META-INF/stub/swagger.json";
-
-    // Location of Swagger YAML doc in module
-    private static final String DEFAULT_SWAGGER_YAML_LOCATION = "META-INF/swagger.yaml";
-
-    // Location of Swagger YAML stub doc in module
-    private static final String DEFAULT_SWAGGER_YAML_STUB_LOCATION = "META-INF/stub/swagger.yaml";
-
-    private final ClassLoader classLoader;
-    private final File warFile;
-    private final File outputFile;
-    private final String tmpPath;
-    private final String[] prefixes;
     
-    
-    private static final Logger logger = Logger.getLogger(SwaggerProcessor.class.getName());
+	// Location of Swagger JSON doc in module
+	private static final String DEFAULT_SWAGGER_JSON_LOCATION = "META-INF/swagger.json";
 
-    public SwaggerProcessor(ClassLoader classLoader, File warFile, File outputFile)
-    {
-    	this(null, ".", classLoader, warFile, outputFile);
-    }
-    
-    public SwaggerProcessor(String[] prefixes, String tmpPath, ClassLoader classLoader, File warFile, File outputFile) {
-        this.classLoader = classLoader;
-        this.warFile = warFile;
-        this.outputFile = outputFile;
-        this.prefixes = prefixes;
-        this.tmpPath = tmpPath;
-    }
-    
-    public void process() {
-        final String document = getDocument();
-        if (document != null) {
-            OutputStreamWriter writer = null;
-            try {
-                writer = new OutputStreamWriter(new FileOutputStream(outputFile), "UTF-8");
-                writer.write(document);
-                writer.flush();
-            } catch (IOException ioe) {
-                logger.severe("Failed to write to the output document " + outputFile.getAbsolutePath());
-            } finally {
-                tryToClose(writer);
-            }
-        }
-    }
+	// Location of Swagger JSON stub doc in module
+	private static final String DEFAULT_SWAGGER_JSON_STUB_LOCATION = "META-INF/stub/swagger.json";
 
-    public String getDocument() {
-        ZipFile warZipFile = null;
-        try {
-            warZipFile = new ZipFile(warFile);
+	// Location of Swagger YAML doc in module
+	private static final String DEFAULT_SWAGGER_YAML_LOCATION = "META-INF/swagger.yaml";
 
-            // Search for META-INF/swagger.json or META-INF/swagger.yaml in the
-            // WAR
-            ZipEntry entry = warZipFile.getEntry(DEFAULT_SWAGGER_JSON_LOCATION);
-            if (entry == null) {
-                entry = warZipFile.getEntry(DEFAULT_SWAGGER_YAML_LOCATION);
-            }
-            if (entry != null) {
-                InputStream swaggerStream = warZipFile.getInputStream(entry);
-                String swaggerDoc = getSwaggerDocFromStream(swaggerStream);
-                // Swagger swaggerModel = new SwaggerParser().parse(swaggerDoc,
-                // null, false);
-                Swagger swaggerModel = new SwaggerParser().parse(swaggerDoc, null);
+	// Location of Swagger YAML stub doc in module
+	private static final String DEFAULT_SWAGGER_YAML_STUB_LOCATION = "META-INF/stub/swagger.yaml";
 
-                return createYAMLfromPojo(swaggerModel);
-            }
+	private final ClassLoader classLoader;
+	private final File warFile;
+	private final File outputFile;
+	private final String tmpPath;
+	private final String[] prefixes;
+	
+	
+	private static final Logger logger = Logger.getLogger(SwaggerProcessor.class.getName());
 
-            // Search for META-INF/stub/swagger.json or
-            // META-INF/stub/swagger.yaml in the WAR
-            Swagger swaggerStubModel = null;
-            entry = warZipFile.getEntry(DEFAULT_SWAGGER_JSON_STUB_LOCATION);
-            if (entry == null) {
-                entry = warZipFile.getEntry(DEFAULT_SWAGGER_YAML_STUB_LOCATION);
-            }
-            if (entry != null) {
-                InputStream swaggerStream = warZipFile.getInputStream(entry);
-                String swaggerDoc = getSwaggerDocFromStream(swaggerStream);
-                swaggerStubModel = new SwaggerParser().parse(swaggerDoc, null);
-            }
-            // Scan the WAR for annotations and merge with the stub document.
-            return getSwaggerDocFromAnnotatedClasses(warZipFile, swaggerStubModel);
-        } catch (IOException ioe) {
-            logger.severe("Failed to generate the Swagger document.");
-        } finally {
-            tryToClose(warZipFile);
-        }
-        return null;
-    }
+	public SwaggerProcessor(ClassLoader classLoader, File warFile, File outputFile)
+	{
+		this(null, ".", classLoader, warFile, outputFile);
+	}
+	
+	public SwaggerProcessor(String[] prefixes, String tmpPath, ClassLoader classLoader, File warFile, File outputFile) {
+		this.classLoader = classLoader;
+		this.warFile = warFile;
+		this.outputFile = outputFile;
+		this.prefixes = prefixes;
+		this.tmpPath = tmpPath;
+	}
+	
+	public void process() {
+		final String document = getDocument();
+		if (document != null) {
+			OutputStreamWriter writer = null;
+			try {
+				writer = new OutputStreamWriter(new FileOutputStream(outputFile), "UTF-8");
+				writer.write(document);
+				writer.flush();
+			} catch (IOException ioe) {
+				logger.severe("Failed to write to the output document " + outputFile.getAbsolutePath());
+			} finally {
+				tryToClose(writer);
+			}
+		}
+	}
 
-    private String getSwaggerDocFromStream(InputStream is) {
-        try {
-            return IOUtils.toString(is, "UTF-8"); // YAML document's format has
-                                                    // to be preserved
-        } catch (IOException ioe) {
-            logger.severe("Cannot read the Swagger document inside the application.");
-        } finally {
-            tryToClose(is);
-        }
-        return null;
-    }
+	public String getDocument() {
+		ZipFile warZipFile = null;
+		try {
+			warZipFile = new ZipFile(warFile);
 
-    private String getSwaggerDocFromAnnotatedClasses(ZipFile warZipFile, Swagger swaggerStubModel) throws IOException {
-        SwaggerAnnotationsScanner annScan = null;
-        try {
-            annScan = new SwaggerAnnotationsScanner(tmpPath, prefixes, classLoader, warZipFile);
-            Set<Class<?>> classes = annScan.getScannedClasses();
-            Reader reader = new Reader(swaggerStubModel);
-            Set<String> stubPaths = null;
-            if (swaggerStubModel != null && swaggerStubModel.getPaths() != null) {
-                stubPaths = swaggerStubModel.getPaths().keySet();
-            }
-            
-            for(Class<?> c : getModelClasses(classes))
-            {
-            		appendModels(c, reader.getSwagger());
-            }
-            
-            Swagger swresult = reader.read(classes);
-            
-            swresult = addUrlMapping(swresult, stubPaths, annScan.getUrlMapping());
-            String ext = FilenameUtils.getExtension(this.outputFile.getName());
-            if (ext.equalsIgnoreCase("json")) {
-                return createJSONfromPojo(swresult);
-            } else if (ext.equalsIgnoreCase("yaml")) {
-                return createYAMLfromPojo(swresult);
-            }
-            throw new IllegalArgumentException("Unsupported document type: " + ext);
-        } finally {
-            if (annScan != null) {
-                annScan.cleanupJarFolder();
-            }
-        }
-    }
+			// Search for META-INF/swagger.json or META-INF/swagger.yaml in the
+			// WAR
+			ZipEntry entry = warZipFile.getEntry(DEFAULT_SWAGGER_JSON_LOCATION);
+			if (entry == null) {
+				entry = warZipFile.getEntry(DEFAULT_SWAGGER_YAML_LOCATION);
+			}
+			if (entry != null) {
+				InputStream swaggerStream = warZipFile.getInputStream(entry);
+				String swaggerDoc = getSwaggerDocFromStream(swaggerStream);
+				// Swagger swaggerModel = new SwaggerParser().parse(swaggerDoc,
+				// null, false);
+				Swagger swaggerModel = new SwaggerParser().parse(swaggerDoc, null);
 
-    private Set<Class<?>> getModelClasses(Set<Class<?>> classes) {
-    	Set<Class<?>> modelClasses = new HashSet<Class<?>>();
-    	for(Class<?> c : classes)
-    	{
-    		if(c.getAnnotation(ApiModel.class) != null)
-    		{
-    			modelClasses.add(c);
-    		}
-    	}
-    	return modelClasses;
+				return createYAMLfromPojo(swaggerModel);
+			}
+
+			// Search for META-INF/stub/swagger.json or
+			// META-INF/stub/swagger.yaml in the WAR
+			Swagger swaggerStubModel = null;
+			entry = warZipFile.getEntry(DEFAULT_SWAGGER_JSON_STUB_LOCATION);
+			if (entry == null) {
+				entry = warZipFile.getEntry(DEFAULT_SWAGGER_YAML_STUB_LOCATION);
+			}
+			if (entry != null) {
+				InputStream swaggerStream = warZipFile.getInputStream(entry);
+				String swaggerDoc = getSwaggerDocFromStream(swaggerStream);
+				swaggerStubModel = new SwaggerParser().parse(swaggerDoc, null);
+			}
+			// Scan the WAR for annotations and merge with the stub document.
+			return getSwaggerDocFromAnnotatedClasses(warZipFile, swaggerStubModel);
+		} catch (IOException ioe) {
+			logger.severe("Failed to generate the Swagger document.");
+		} finally {
+			tryToClose(warZipFile);
+		}
+		return null;
+	}
+
+	private String getSwaggerDocFromStream(InputStream is) {
+		try {
+			return IOUtils.toString(is, "UTF-8"); // YAML document's format has
+													// to be preserved
+		} catch (IOException ioe) {
+			logger.severe("Cannot read the Swagger document inside the application.");
+		} finally {
+			tryToClose(is);
+		}
+		return null;
+	}
+
+	private String getSwaggerDocFromAnnotatedClasses(ZipFile warZipFile, Swagger swaggerStubModel) throws IOException {
+		SwaggerAnnotationsScanner annScan = null;
+		try {
+			annScan = new SwaggerAnnotationsScanner(tmpPath, prefixes, classLoader, warZipFile);
+			Set<Class<?>> classes = annScan.getScannedClasses();
+			Reader reader = new Reader(swaggerStubModel);
+			Set<String> stubPaths = null;
+			if (swaggerStubModel != null && swaggerStubModel.getPaths() != null) {
+				stubPaths = swaggerStubModel.getPaths().keySet();
+			}
+			
+			for(Class<?> c : getModelClasses(classes))
+			{
+					appendModels(c, reader.getSwagger());
+			}
+			
+			Swagger swresult = reader.read(classes);
+			
+			swresult = addUrlMapping(swresult, stubPaths, annScan.getUrlMapping());
+			String ext = FilenameUtils.getExtension(this.outputFile.getName());
+			if (ext.equalsIgnoreCase("json")) {
+				return createJSONfromPojo(swresult);
+			} else if (ext.equalsIgnoreCase("yaml")) {
+				return createYAMLfromPojo(swresult);
+			}
+			throw new IllegalArgumentException("Unsupported document type: " + ext);
+		} finally {
+			if (annScan != null) {
+				annScan.cleanupJarFolder();
+			}
+		}
+	}
+
+	private Set<Class<?>> getModelClasses(Set<Class<?>> classes) {
+		Set<Class<?>> modelClasses = new HashSet<Class<?>>();
+		for(Class<?> c : classes)
+		{
+			if(c.getAnnotation(ApiModel.class) != null)
+			{
+				modelClasses.add(c);
+			}
+		}
+		return modelClasses;
 	}
 
 	private Swagger addUrlMapping(Swagger result, Set<String> ignorePaths, Object urlMappings) {
-        if (urlMappings == null || "".equals(urlMappings)) {
-            return result;
-        }
+		if (urlMappings == null || "".equals(urlMappings)) {
+			return result;
+		}
 
-        Map<String, Path> paths = result.getPaths();
-        Map<String, Path> newPaths = new HashMap<String, Path>();
+		Map<String, Path> paths = result.getPaths();
+		Map<String, Path> newPaths = new HashMap<String, Path>();
+		
+		if (urlMappings instanceof String) {
+		    final String urlMapping = (String) urlMappings;
+		    for (Entry<String, Path> pathEntry : paths.entrySet()) {
+		        if (ignorePaths != null && ignorePaths.contains(pathEntry.getKey())) {
+		            newPaths.put(pathEntry.getKey(), pathEntry.getValue());
+		            continue;
+		        }
+		        newPaths.put(urlMapping + pathEntry.getKey(), pathEntry.getValue());
+		    }
+		}
+		else {
+		    @SuppressWarnings("unchecked")
+		    Map<String, String> mappings = (Map<String, String>) urlMappings;
+		    for (Entry<String, Path> pathEntry : paths.entrySet()) {
+		        final String urlMapping = mappings.get(pathEntry.getKey());
+		        if ((ignorePaths != null && ignorePaths.contains(pathEntry.getKey())) || urlMapping == null) {
+		            newPaths.put(pathEntry.getKey(), pathEntry.getValue());
+		            continue;
+		        }
+		        newPaths.put(urlMapping + pathEntry.getKey(), pathEntry.getValue());
+		    }
+		}
 
-        if (urlMappings instanceof String) {
-            final String urlMapping = (String) urlMappings;
-            for (Entry<String, Path> pathEntry : paths.entrySet()) {
-                if (ignorePaths != null && ignorePaths.contains(pathEntry.getKey())) {
-                    newPaths.put(pathEntry.getKey(), pathEntry.getValue());
-                    continue;
-                }
-                newPaths.put(urlMapping + pathEntry.getKey(), pathEntry.getValue());
-            }
-        } else {
-            @SuppressWarnings("unchecked")
-            Map<String, String> mappings = (Map<String, String>) urlMappings;
-            for (Entry<String, Path> pathEntry : paths.entrySet()) {
-                final String urlMapping = mappings.get(pathEntry.getKey());
-                if ((ignorePaths != null && ignorePaths.contains(pathEntry.getKey())) || urlMapping == null) {
-                    newPaths.put(pathEntry.getKey(), pathEntry.getValue());
-                    continue;
-                }
-                newPaths.put(urlMapping + pathEntry.getKey(), pathEntry.getValue());
-            }
-        }
+		result.setPaths(newPaths);
+		return result;
+	}
 
-        result.setPaths(newPaths);
-        return result;
-    }
+	private String createYAMLfromPojo(Object pojo) throws IOException {
+		return Yaml.mapper().writeValueAsString(pojo);
+	}
 
-    private String createYAMLfromPojo(Object pojo) throws IOException {
-        return Yaml.mapper().writeValueAsString(pojo);
-    }
+	private void tryToClose(Closeable c) {
+		if (c != null) {
+			try {
+				c.close();
+			} catch (IOException ioe) {
+				logger.severe("Failed to successfully close the file.");
+			}
+		}
+	}
 
-    private void tryToClose(Closeable c) {
-        if (c != null) {
-            try {
-                c.close();
-            } catch (IOException ioe) {
-                logger.severe("Failed to successfully close the file.");
-            }
-        }
-    }
-
-    private String createJSONfromPojo(Object pojo) throws IOException {
-        return Json.pretty(pojo);
-    }
-    
-    private void appendModels(Type type, Swagger swagger) {
-        final Map<String, Model> models = ModelConverters.getInstance().read(type);
-        for (Map.Entry<String, Model> entry : models.entrySet()) {
-            swagger.model(entry.getKey(), entry.getValue());
-        }
-    }
+	private String createJSONfromPojo(Object pojo) throws IOException {
+		return Json.pretty(pojo);
+	}
+	
+	private void appendModels(Type type, Swagger swagger) {
+		final Map<String, Model> models = ModelConverters.getInstance().read(type);
+		for (Map.Entry<String, Model> entry : models.entrySet()) {
+			swagger.model(entry.getKey(), entry.getValue());
+		}
+	}
 }

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
@@ -63,7 +63,7 @@ public class SwaggerProcessor {
     private final File warFile;
     private final File outputFile;
     private final String tmpPath;
-    private final String[] packageNames;
+    private final String[] prefixes;
     
     
     private static final Logger logger = Logger.getLogger(SwaggerProcessor.class.getName());
@@ -73,11 +73,11 @@ public class SwaggerProcessor {
     	this(null, ".", classLoader, warFile, outputFile);
     }
     
-    public SwaggerProcessor(String[] packageNames, String tmpPath, ClassLoader classLoader, File warFile, File outputFile) {
+    public SwaggerProcessor(String[] prefixes, String tmpPath, ClassLoader classLoader, File warFile, File outputFile) {
         this.classLoader = classLoader;
         this.warFile = warFile;
         this.outputFile = outputFile;
-        this.packageNames = packageNames;
+        this.prefixes = prefixes;
         this.tmpPath = tmpPath;
     }
     
@@ -155,7 +155,7 @@ public class SwaggerProcessor {
     private String getSwaggerDocFromAnnotatedClasses(ZipFile warZipFile, Swagger swaggerStubModel) throws IOException {
         SwaggerAnnotationsScanner annScan = null;
         try {
-            annScan = new SwaggerAnnotationsScanner(tmpPath, packageNames, classLoader, warZipFile);
+            annScan = new SwaggerAnnotationsScanner(tmpPath, prefixes, classLoader, warZipFile);
             Set<Class<?>> classes = annScan.getScannedClasses();
             Reader reader = new Reader(swaggerStubModel);
             Set<String> stubPaths = null;

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
@@ -65,9 +65,13 @@ public class SwaggerProcessor {
         this.warFile = warFile;
         this.outputFile = outputFile;
     }
-
+    
     public void process() {
-        final String document = getDocument();
+    	process(null);
+    }
+    
+    public void process(String packageName) {
+        final String document = getDocument(packageName);
         if (document != null) {
             OutputStreamWriter writer = null;
             try {
@@ -82,7 +86,7 @@ public class SwaggerProcessor {
         }
     }
 
-    public String getDocument() {
+    public String getDocument(String packageName) {
         ZipFile warZipFile = null;
         try {
             warZipFile = new ZipFile(warFile);
@@ -116,7 +120,7 @@ public class SwaggerProcessor {
                 swaggerStubModel = new SwaggerParser().parse(swaggerDoc, null);
             }
             // Scan the WAR for annotations and merge with the stub document.
-            return getSwaggerDocFromAnnotatedClasses(warZipFile, swaggerStubModel);
+            return getSwaggerDocFromAnnotatedClasses(warZipFile, swaggerStubModel, packageName);
         } catch (IOException ioe) {
             logger.severe("Failed to generate the Swagger document.");
         } finally {
@@ -137,10 +141,10 @@ public class SwaggerProcessor {
         return null;
     }
 
-    private String getSwaggerDocFromAnnotatedClasses(ZipFile warZipFile, Swagger swaggerStubModel) throws IOException {
+    private String getSwaggerDocFromAnnotatedClasses(ZipFile warZipFile, Swagger swaggerStubModel, String packageName) throws IOException {
         SwaggerAnnotationsScanner annScan = null;
         try {
-            annScan = new SwaggerAnnotationsScanner(classLoader, warZipFile);
+            annScan = new SwaggerAnnotationsScanner(packageName, classLoader, warZipFile);
             Set<Class<?>> classes = annScan.getScannedClasses();
             Reader reader = new Reader(swaggerStubModel);
             Set<String> stubPaths = null;

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
@@ -41,7 +41,7 @@ import io.swagger.util.Json;
 import io.swagger.util.Yaml;
 
 public class SwaggerProcessor {
-    
+
 	// Location of Swagger JSON doc in module
 	private static final String DEFAULT_SWAGGER_JSON_LOCATION = "META-INF/swagger.json";
 
@@ -139,8 +139,7 @@ public class SwaggerProcessor {
 
 	private String getSwaggerDocFromAnnotatedClasses(ZipFile warZipFile, Swagger swaggerStubModel) throws IOException {
 		SwaggerAnnotationsScanner annScan = null;
-		try
-		{
+		try {
 			annScan = new SwaggerAnnotationsScanner(classLoader, warZipFile);
 			Set<Class<?>> classes = annScan.getScannedClasses();
 			Reader reader = new Reader(swaggerStubModel);
@@ -153,15 +152,12 @@ public class SwaggerProcessor {
 			String ext = FilenameUtils.getExtension(this.outputFile.getName());
 			if (ext.equalsIgnoreCase("json")) {
 				return createJSONfromPojo(swresult);
-			} else if (ext.equalsIgnoreCase("yaml")){
+			} else if (ext.equalsIgnoreCase("yaml")) {
 				return createYAMLfromPojo(swresult);
 			}
 			throw new IllegalArgumentException("Unsupported document type: " + ext);
-		}
-		finally
-		{
-			if(annScan != null)
-			{
+		} finally {
+			if (annScan != null) {
 				annScan.cleanupJarFolder();
 			}
 		}
@@ -174,28 +170,27 @@ public class SwaggerProcessor {
 
 		Map<String, Path> paths = result.getPaths();
 		Map<String, Path> newPaths = new HashMap<String, Path>();
-		
+
 		if (urlMappings instanceof String) {
-		    final String urlMapping = (String) urlMappings;
-		    for (Entry<String, Path> pathEntry : paths.entrySet()) {
-		        if (ignorePaths != null && ignorePaths.contains(pathEntry.getKey())) {
-		            newPaths.put(pathEntry.getKey(), pathEntry.getValue());
-		            continue;
-		        }
-		        newPaths.put(urlMapping + pathEntry.getKey(), pathEntry.getValue());
-		    }
-		}
-		else {
-		    @SuppressWarnings("unchecked")
-		    Map<String, String> mappings = (Map<String, String>) urlMappings;
-		    for (Entry<String, Path> pathEntry : paths.entrySet()) {
-		        final String urlMapping = mappings.get(pathEntry.getKey());
-		        if ((ignorePaths != null && ignorePaths.contains(pathEntry.getKey())) || urlMapping == null) {
-		            newPaths.put(pathEntry.getKey(), pathEntry.getValue());
-		            continue;
-		        }
-		        newPaths.put(urlMapping + pathEntry.getKey(), pathEntry.getValue());
-		    }
+			final String urlMapping = (String) urlMappings;
+			for (Entry<String, Path> pathEntry : paths.entrySet()) {
+				if (ignorePaths != null && ignorePaths.contains(pathEntry.getKey())) {
+					newPaths.put(pathEntry.getKey(), pathEntry.getValue());
+					continue;
+				}
+				newPaths.put(urlMapping + pathEntry.getKey(), pathEntry.getValue());
+			}
+		} else {
+			@SuppressWarnings("unchecked")
+			Map<String, String> mappings = (Map<String, String>) urlMappings;
+			for (Entry<String, Path> pathEntry : paths.entrySet()) {
+				final String urlMapping = mappings.get(pathEntry.getKey());
+				if ((ignorePaths != null && ignorePaths.contains(pathEntry.getKey())) || urlMapping == null) {
+					newPaths.put(pathEntry.getKey(), pathEntry.getValue());
+					continue;
+				}
+				newPaths.put(urlMapping + pathEntry.getKey(), pathEntry.getValue());
+			}
 		}
 
 		result.setPaths(newPaths);

--- a/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
+++ b/src/main/java/net/wasdev/maven/plugins/swaggerdocgen/SwaggerProcessor.java
@@ -58,7 +58,7 @@ public class SwaggerProcessor {
     private final File warFile;
     private final File outputFile;
     private final String tmpPath;
-    private final String packageName;
+    private final String[] packageNames;
     
     
     private static final Logger logger = Logger.getLogger(SwaggerProcessor.class.getName());
@@ -68,11 +68,11 @@ public class SwaggerProcessor {
     	this(null, ".", classLoader, warFile, outputFile);
     }
     
-    public SwaggerProcessor(String packageName, String tmpPath, ClassLoader classLoader, File warFile, File outputFile) {
+    public SwaggerProcessor(String[] packageNames, String tmpPath, ClassLoader classLoader, File warFile, File outputFile) {
         this.classLoader = classLoader;
         this.warFile = warFile;
         this.outputFile = outputFile;
-        this.packageName = packageName;
+        this.packageNames = packageNames;
         this.tmpPath = tmpPath;
     }
     
@@ -150,7 +150,7 @@ public class SwaggerProcessor {
     private String getSwaggerDocFromAnnotatedClasses(ZipFile warZipFile, Swagger swaggerStubModel) throws IOException {
         SwaggerAnnotationsScanner annScan = null;
         try {
-            annScan = new SwaggerAnnotationsScanner(tmpPath, packageName, classLoader, warZipFile);
+            annScan = new SwaggerAnnotationsScanner(tmpPath, packageNames, classLoader, warZipFile);
             Set<Class<?>> classes = annScan.getScannedClasses();
             Reader reader = new Reader(swaggerStubModel);
             Set<String> stubPaths = null;


### PR DESCRIPTION
Hi,

I did more work on this code so I could use it with another project. I wasn't sure what I could share so I worked on an IBM git repo. Being the github noob that I am I deleted the my old repo, the one from which pull request #10 was from. Consequently, I am resubmitting a pull request from this new repository and I will close the old pull request, #10 .

The differences from this repository are:
- added class loading from the WEB-INF\lib folder in the WAR file
- added looking for resource classes in WEB-INF\lib too, since it is supported by JAX-RS
- added a parameter for the path where the WEB-INF\lib gets unpacked, for flexibility and manual cleanup if necessary
- added the possibility to filter what classes will make it into the documentation by the prefixes of the classes (think String.startsWith)
- classes annotated with @ApiModel were not included in the documentation unless they were explicitly used by resource methods; I made then be included in the documentation regardless
- implemented the changes requested by the reviewers of pull request #10 